### PR TITLE
PluralForm module for plurals

### DIFF
--- a/locale/de-DE/floatnotes.properties
+++ b/locale/de-DE/floatnotes.properties
@@ -1,7 +1,9 @@
 hideNotesString=Notizen verstecken
 showNotesString=Notizen anzeigen (%S)
-singularNote=Notiz
-pluralNote=Notizen
+# Indicators for notes that are outside the current view.
+#	These are semi-colon list of plural forms.
+# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
+indicatorNote=Notiz;Notizen
 aboveIndicatorString=oben
 belowIndicatorString=unten
 

--- a/locale/en-US/floatnotes.properties
+++ b/locale/en-US/floatnotes.properties
@@ -1,7 +1,9 @@
 hideNotesString=Hide notes
 showNotesString=Show notes (%S)
-singularNote=note
-pluralNote=notes
+# Indicators for notes that are outside the current view.
+#	These are semi-colon list of plural forms.
+# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
+indicatorNote=note;notes
 aboveIndicatorString=above
 belowIndicatorString=below
 

--- a/locale/es/floatnotes.properties
+++ b/locale/es/floatnotes.properties
@@ -1,7 +1,9 @@
 hideNotesString=Ocultar notas
 showNotesString=Mostrar notas (%S)
-singularNote=nota
-pluralNote=notas
+# Indicators for notes that are outside the current view.
+#	These are semi-colon list of plural forms.
+# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
+indicatorNote=nota;notas
 aboveIndicatorString=arriba
 belowIndicatorString=abajo
 

--- a/locale/it-IT/floatnotes.properties
+++ b/locale/it-IT/floatnotes.properties
@@ -1,7 +1,9 @@
 hideNotesString=Nascondi note
 showNotesString=Mostra note (%S)
-singularNote=nota
-pluralNote=note
+# Indicators for notes that are outside the current view.
+#	These are semi-colon list of plural forms.
+# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
+indicatorNote=nota;note
 aboveIndicatorString=sopra
 belowIndicatorString=sotto
 

--- a/locale/pl/floatnotes.properties
+++ b/locale/pl/floatnotes.properties
@@ -1,7 +1,9 @@
 hideNotesString=Ukryj notatki
 showNotesString=Pokaż notatki (%S)
-singularNote=notatka
-pluralNote=notatek
+# Indicators for notes that are outside the current view.
+#	These are semi-colon list of plural forms.
+# See: http://developer.mozilla.org/en/docs/Localization_and_Plurals
+indicatorNote=notatka;notatki;notatek
 aboveIndicatorString=powyżej
 belowIndicatorString=poniżej
 

--- a/src/XUL/notelist.js
+++ b/src/XUL/notelist.js
@@ -5,6 +5,7 @@ Components.utils.import("resource://floatnotes/util-Locale.js");
 Components.utils.import("resource://floatnotes/util-Dialog.js");
 Components.utils.import("resource://floatnotes/URLHandler.js");
 Components.utils.import("resource://floatnotes/Shared.js");
+Components.utils.import("resource://gre/modules/PluralForm.jsm");
 
 var textBox = document.getElementById('text');
 var colorPicker = document.getElementById('color');
@@ -269,12 +270,7 @@ function getTitle(text) {
 
 function updateCounter() {
     var str = treeView.rowCount;
-    if(str === 1) {
-        str += ' ' + Locale.get('singularNote');
-    }
-    else {
-        str += ' ' + Locale.get('pluralNote');
-    }
+    str += ' ' + PluralForm.get(str, Locale.get('indicatorNote'));
     document.getElementById('counter').value = str;
 }
 

--- a/src/js/modules/InPageIndicator.js
+++ b/src/js/modules/InPageIndicator.js
@@ -1,4 +1,29 @@
-//!#include "../header.js"
+Components.utils.import("resource://gre/modules/PluralForm.jsm");
+
+
+
+var Cc = Components.classes;
+var Ci = Components.interfaces;
+var Cr = Components.results;
+var Cu = Components.utils;
+var Util = (function() {
+    var modules = ['Dom', 'Js', 'Locale', 'Css', 'Mozilla', 'Platform', 'Dialog'];
+    var t = {_modules:{}};
+    for(var i  = modules.length; i--;) {
+        var module = modules[i];
+        t.__defineGetter__(module, (function(module) {
+            return function() {
+                Cu.import("resource://floatnotes/util-" + module + ".js", this._modules);
+                this.__defineGetter__(module, function() {
+                    return this._modules[module];
+                });
+                return this[module];
+            };
+        }(module)));
+    }
+    return t;
+}());
+Cu.import("resource://floatnotes/Shared.js");
 
 Cu.import("resource://floatnotes/preferences.js");
 
@@ -78,7 +103,7 @@ Indicator.prototype = {
         if(this.ele) {
             var count = 0;
             this.lastNotes = this._getCurrentNotesFrom(notes);
-            count = this.lastNotes.length; LOG(count + ' notes ' + this.type);
+            count = this.lastNotes.length; ;
 
             if(count > 0) {
                 if(count != this.lastCount) {
@@ -103,7 +128,7 @@ Indicator.prototype = {
     },
 
     _updateLabel: function(nn_notes) {
-        this.ele.label.innerHTML = nn_notes + ' ' + (nn_notes > 1 ? Util.Locale.get('pluralNote'): Util.Locale.get('singularNote')) +  " " + this.label;
+        this.ele.label.innerHTML = nn_notes + ' ' + PluralForm.get(nn_notes, Util.Locale.get('indicatorNote')) +  " " + this.label;
     },
 
     _show: function() {


### PR DESCRIPTION
Use for plurals PluralForm, this is better for languages with more/less than 2 plural forms, e.g. Polish, French. See https://developer.mozilla.org/en/Localization_and_Plurals

I finished ;)
